### PR TITLE
Switch langchain_blog source to www.langchain.com sitemap

### DIFF
--- a/config/sources.yaml
+++ b/config/sources.yaml
@@ -112,8 +112,12 @@ sources:
     url: "https://www.latent.space/feed"
     weight: 1.2
   - name: langchain_blog
-    type: rss
-    url: "https://blog.langchain.com/rss/"
+    type: sitemap
+    url: "https://www.langchain.com/sitemap.xml"
+    include_prefixes:
+      - "https://www.langchain.com/blog/"
+    extract_published_from_page: true
+    page_meta_cache_ttl_hours: 24
     weight: 1.05
   - name: search_agent_engineering_news
     type: rss


### PR DESCRIPTION
## Summary
- The legacy `https://blog.langchain.com/rss/` feed has been returning **0 items for 74 consecutive ingest runs** (`data/health/ingest_runs.jsonl`), so no LangChain blog posts are reaching the feed.
- LangChain has migrated their blog content to `https://www.langchain.com/blog/` (e.g. `tuning-deep-agents-different-models`).
- This PR swaps `langchain_blog` from `type: rss` over the dead Ghost feed to `type: sitemap` over `https://www.langchain.com/sitemap.xml` filtered to `/blog/` URLs, mirroring the existing `claude_blog` / `anthropic_*` pattern with `extract_published_from_page: true` and a 24h page-meta cache. Weight unchanged at `1.05`.

## Test plan
- [ ] After merge, confirm next collector run produces `langchain_blog` rows in `data/health/ingest_runs.jsonl` with `items > 0`.
- [ ] Confirm `data/raw/<today>/items.json` contains entries with URLs starting `https://www.langchain.com/blog/`.
- [ ] Spot-check that the article `tuning-deep-agents-different-models` (the trigger for this work) shows up in a subsequent feed.
- [ ] If `items=0` persists, sanity-check that `https://www.langchain.com/sitemap.xml` exists and includes `/blog/` URLs (this couldn't be verified from the dev sandbox due to network restrictions).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xs5K3z39chMsSVMPDfdjRX)_